### PR TITLE
Fix Config Key in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Connection to rackspace API's will require your username and either your account
 
 You can configure the rackspace library by adding a config section to your Application config
 ```elixir
-config :rackspace, :auth,
+config :rackspace, :api,
   api_key: "xxxxxxxxxxxxxx",
   username: "yyyyyyyyyyyyy",
   password: "zzzzzzzzzzzzz"


### PR DESCRIPTION
The README says to use `:auth` as the key for accessing the config, but in code its `:api` (https://github.com/livehelpnow/ex-rackspace/blob/master/lib/rackspace.ex#L13). Changed the readme to reflect this.
