### PR TITLE
Fix warnings

### DIFF
--- a/lib/rackspace/api/cloud_files.ex
+++ b/lib/rackspace/api/cloud_files.ex
@@ -1,9 +1,9 @@
 defmodule Rackspace.Api.CloudFiles do
 
-  def base_url(region, opts \\ []) do
-    region = Application.get_env(:rackspace, :cloudFiles)
+  def base_url(region, _opts \\ []) do
+    _region = Application.get_env(:rackspace, :cloudFiles)
       |> Keyword.get(:endpoints)
-      |> Enum.find(fn(ep) ->  
+      |> Enum.find(fn(ep) ->
         String.downcase(ep["region"]) == String.downcase(region)
       end)
       |> Map.get("publicURL")

--- a/lib/rackspace/api/cloud_files/object.ex
+++ b/lib/rackspace/api/cloud_files/object.ex
@@ -45,7 +45,7 @@ defmodule Rackspace.Api.CloudFiles.Object do
     case validate_resp(resp) do
       {:ok, _} ->
         Logger.debug "Response Headers: #{inspect resp.headers}"
-        metadata = Enum.filter(resp.headers, fn({k,v}) ->
+        metadata = Enum.filter(resp.headers, fn({k,_v}) ->
           to_string(k)
             |> String.starts_with?("X-Object-Meta")
         end)

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Rackspace.Mixfile do
 
   def project do
     [app: :rackspace,
-     version: "0.0.1",
+     version: "0.0.2",
      elixir: "~> 1.0",
      deps: deps]
   end


### PR DESCRIPTION
## What

Fix three compile warnings.

```
==> rackspace
Compiling 8 files (.ex)
warning: variable opts is unused
  lib/rackspace/api/cloud_files.ex:3

warning: variable region is unused
  lib/rackspace/api/cloud_files.ex:4

warning: variable v is unused
  lib/rackspace/api/cloud_files/object.ex:48
```
